### PR TITLE
change example action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Run JavaScript instead of shell script in GitHub Actions.
 ## Example
 ```yaml
 - name: Output current branch name & date
-  # To use latest action, specify "release-master" instead of "v0.0.3"
-  uses: satackey/action-js-inline@v0.0.3
+  # To use latest action, specify "release-master" instead of "v0.0.2"
+  uses: satackey/action-js-inline@v0.0.2
   id: getdata
   with:
     # Edit the following line to install packages required to run your script.


### PR DESCRIPTION
Thank you for developing a good github action.
The example version doesn't exist, so I changed it to 0.0.2.

<img width="886" alt="" src="https://user-images.githubusercontent.com/21009186/107849726-99aac500-6e40-11eb-88b8-fb5190997b0a.png">

ref
https://github.com/satackey/action-js-inline/tags