### PR TITLE
Updating deprecated node version.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: true
 
 runs:
-  using: node12
+  using: node16
   main: index.ts


### PR DESCRIPTION
Fixing the message below:

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: satackey/action-js-inline@v0.0.2